### PR TITLE
Fix discrepancy between symbols count

### DIFF
--- a/Sources/CookInSwift/Lexer/Lexer.swift
+++ b/Sources/CookInSwift/Lexer/Lexer.swift
@@ -33,7 +33,7 @@ public class Lexer {
 
     public init(_ text: String) {
         self.text = Array(text.unicodeScalars)
-        self.count = text.count
+        self.count = self.text.count
         currentPosition = 0
         currentCharacter = text.isEmpty ? nil : self.text[0]
     }

--- a/Tests/CookInSwiftTests/LexerTests.swift
+++ b/Tests/CookInSwiftTests/LexerTests.swift
@@ -31,6 +31,17 @@ class LexerTests: XCTestCase {
         XCTAssertEqual(lexer.getNextToken(), .constant(.space))
         XCTAssertEqual(lexer.getNextToken(), .eof)
     }
+
+    func testWindowsNewLineInput() {
+        let input = "abc\r\ndef\r\nghi"
+        let lexer = Lexer(input)
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("abc")))
+        XCTAssertEqual(lexer.getNextToken(), .eol)
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("def")))
+        XCTAssertEqual(lexer.getNextToken(), .eol)
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("ghi")))
+        XCTAssertEqual(lexer.getNextToken(), .eof)
+    }
     
     func testMultipleNewLinesInput() {
         let input = "   \n\n    "


### PR DESCRIPTION
On Windows lines separated by "\r\n" instead of just "\n". When checking length of string it counts "\r\n" as one symbol, but when converted to array of unicode scalars it splits them in two.

Fixing https://github.com/cooklang/CookInSwift/issues/8 and https://github.com/cooklang/CookInSwift/issues/9