### PR TITLE
Match EBNF: ingredient and cookware name

### DIFF
--- a/Sources/CookInSwift/Parser/Parser.swift
+++ b/Sources/CookInSwift/Parser/Parser.swift
@@ -126,6 +126,8 @@ public class Parser {
             case .at, .hash:
                 if case .constant(.string) = nextToken {
                     return DirectionNode(items.joined())
+                } else if case .constant(.integer) = nextToken {
+                    return DirectionNode(items.joined())
                 } else {
                     items.append(currentToken.literal)
                     eat(currentToken)

--- a/Tests/CookInSwiftTests/LexerTests.swift
+++ b/Tests/CookInSwiftTests/LexerTests.swift
@@ -47,6 +47,13 @@ class LexerTests: XCTestCase {
         XCTAssertEqual(lexer.getNextToken(), .constant(.string("abc")))
         XCTAssertEqual(lexer.getNextToken(), .eof)
     }
+
+    func testEmoji() {
+        let input = "🍚"
+        let lexer = Lexer(input)
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("🍚")))
+        XCTAssertEqual(lexer.getNextToken(), .eof)
+    }
     
     func testConcessiveStrings() {
         let input = "abc xyz"

--- a/Tests/CookInSwiftTests/ParserTests.swift
+++ b/Tests/CookInSwiftTests/ParserTests.swift
@@ -231,6 +231,42 @@ class ParserTests: XCTestCase {
         
         XCTAssertEqual(result, node)
     }
+
+    func testIngredientMultipleWordsWithLeadingNumber() {
+        let recipe =
+            """
+            Top with @1000 island dressing{ }
+            """
+
+        let result = try! Parser.parse(recipe) as! RecipeNode
+
+        let steps = [
+            StepNode(instructions: [
+                    DirectionNode("Top with "),
+                    IngredientNode(name: "1000 island dressing", amount: AmountNode(quantity: ConstantNode.integer(1)))]),
+        ]
+        let node = RecipeNode(steps: steps)
+
+        XCTAssertEqual(result, node)
+    }
+
+    func testIngredientWithEmoji() {
+        let recipe =
+            """
+            Add some @🧂
+            """
+
+        let result = try! Parser.parse(recipe) as! RecipeNode
+
+        let steps = [
+            StepNode(instructions: [
+                    DirectionNode("Add some "),
+                    IngredientNode(name: "🧂", amount: AmountNode(quantity: ConstantNode.integer(1)))]),
+        ]
+        let node = RecipeNode(steps: steps)
+
+        XCTAssertEqual(result, node)
+    }
     
     func testIngridentWithoutStopper() {
         let recipe =
@@ -383,6 +419,24 @@ class ParserTests: XCTestCase {
             StepNode(instructions: [
                     DirectionNode("Fry in "),
                     EquipmentNode(name: "frying pan")]),
+        ]
+        let node = RecipeNode(steps: steps)
+
+        XCTAssertEqual(result, node)
+    }
+
+    func testEquipmentMultipleWordsWithLeadingNumber() {
+        let recipe =
+            """
+            Fry in #7-inch nonstick frying pan{ }
+            """
+
+        let result = try! Parser.parse(recipe) as! RecipeNode
+
+        let steps = [
+            StepNode(instructions: [
+                    DirectionNode("Fry in "),
+                    EquipmentNode(name: "7-inch nonstick frying pan")]),
         ]
         let node = RecipeNode(steps: steps)
 


### PR DESCRIPTION
Add support for leading numbers and emoji in ingredient and cookware name.

Fixing https://github.com/cooklang/CookInSwift/issues/5.