### PR TITLE
Breaking: new comments

### DIFF
--- a/Sources/CookInSwift/Lexer/Lexer.swift
+++ b/Sources/CookInSwift/Lexer/Lexer.swift
@@ -262,7 +262,7 @@ public class Lexer {
     
     private func punctuation() -> Token {
         var lexem = ""
-        while let character = currentCharacter, !["{", "}", "@", "%", "/", ":", ">", "|"].contains(character) && (CharacterSet.punctuationCharacters.contains(character) || CharacterSet.symbols.contains(character)) {
+        while let character = currentCharacter, !["{", "}", "@", "%", ":", ">", "|"].contains(character) && (CharacterSet.punctuationCharacters.contains(character) || CharacterSet.symbols.contains(character)) {
             lexem += String(character)
             advance()
         }
@@ -344,21 +344,21 @@ public class Lexer {
                 return .tilde
             }
             
-            if currentCharacter == "/" {
+            if currentCharacter == "-" {
                 let nextCharacter = peek()
                 
                 advance()
                 
                 if let unwrapped = nextCharacter {
-                    if unwrapped == "/" {
+                    if unwrapped == "-" {
                         advance()
                         skipComment()
                         return .eol
                     } else {
-                        return .constant(.string("/"))
+                        return .constant(.string("-"))
                     }
                 } else {
-                    return .constant(.string("/"))
+                    return .constant(.string("-"))
                 }
             }
 

--- a/Sources/CookInSwift/Lexer/Lexer.swift
+++ b/Sources/CookInSwift/Lexer/Lexer.swift
@@ -69,6 +69,24 @@ public class Lexer {
     }
 
     /**
+     Skips block comments
+     */
+    private func skipBlockComment() {
+        var prevCharacter = Unicode.Scalar("");
+
+        while let character = currentCharacter {
+            if prevCharacter == "-" && character == "]" {
+                advance()
+
+                return
+            }
+
+            prevCharacter = character
+            advance()
+        }
+    }
+
+    /**
      Advances by one character forward, sets the current character (if still any available)
      */
     private func advance() {
@@ -299,6 +317,24 @@ public class Lexer {
                 return number()
             }
 
+            if currentCharacter == "[" {
+                let nextCharacter = peek()
+
+                advance()
+
+                if let unwrapped = nextCharacter {
+                    if unwrapped == "-" {
+                        advance()
+                        skipBlockComment()
+                        continue
+                    } else {
+                        return .constant(.string("["))
+                    }
+                } else {
+                    return .constant(.string("["))
+                }
+            }
+
             if currentCharacter == "@" {
                 advance()
                 return .at
@@ -311,6 +347,7 @@ public class Lexer {
             
             if currentCharacter == "{" {
                 advance()
+
                 return .braces(.left)
             }
 

--- a/Tests/CookInSwiftTests/LexerTests.swift
+++ b/Tests/CookInSwiftTests/LexerTests.swift
@@ -295,8 +295,56 @@ class LexerTests: XCTestCase {
         XCTAssertEqual(lexer.getNextToken(), .eol)
         XCTAssertEqual(lexer.getNextToken(), .eof)
     }
+
+    func testBlockComments() {
+        let input = "visible [- hidden -] visible"
+        let lexer = Lexer(input)
+
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("visible")))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.space))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.space))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("visible")))
+        XCTAssertEqual(lexer.getNextToken(), .eof)
+    }
+
+    func testBlockCommentsMultiline() {
+        let input = """
+        visible [- hidden
+        hidden
+        hidden -] visible
+        """
+        let lexer = Lexer(input)
+
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("visible")))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.space))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.space))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("visible")))
+        XCTAssertEqual(lexer.getNextToken(), .eof)
+    }
+
+    func testBlockCommentsMultilineUnfinished() {
+        let input = """
+        visible [- hidden
+        hidden
+        hidden
+        """
+        let lexer = Lexer(input)
+
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("visible")))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.space))
+        XCTAssertEqual(lexer.getNextToken(), .eof)
+    }
+
+    func testBlockCommentsUnfinished() {
+        let input = "visible [- hidden"
+        let lexer = Lexer(input)
+
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("visible")))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.space))
+        XCTAssertEqual(lexer.getNextToken(), .eof)
+    }
     
-    func testSlashLast() {
+    func testDashLast() {
         let input = "onions -"
         let lexer = Lexer(input)
         
@@ -306,8 +354,8 @@ class LexerTests: XCTestCase {
         XCTAssertEqual(lexer.getNextToken(), .eof)
     }
     
-    func testSlashInText() {
-        let input = "Preheat the oven to 200℃/Fan 180°C."
+    func testDashInText() {
+        let input = "Preheat the oven to 200℃-Fan 180°C."
         let lexer = Lexer(input)
         
         XCTAssertEqual(lexer.getNextToken(), .constant(.string("Preheat")))
@@ -319,8 +367,32 @@ class LexerTests: XCTestCase {
         XCTAssertEqual(lexer.getNextToken(), .constant(.string("to")))
         XCTAssertEqual(lexer.getNextToken(), .constant(.space))
         XCTAssertEqual(lexer.getNextToken(), .constant(.integer(200)))
-        XCTAssertEqual(lexer.getNextToken(), .constant(.string("℃/")))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("℃-")))
         XCTAssertEqual(lexer.getNextToken(), .constant(.string("Fan")))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.space))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.integer(180)))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("°")))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("C")))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string(".")))
+        XCTAssertEqual(lexer.getNextToken(), .eof)
+    }
+
+    func testSquareInText() {
+        let input = "Preheat the oven to 200℃[Fan] 180°C."
+        let lexer = Lexer(input)
+
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("Preheat")))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.space))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("the")))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.space))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("oven")))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.space))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("to")))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.space))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.integer(200)))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("℃[")))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("Fan")))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("]")))
         XCTAssertEqual(lexer.getNextToken(), .constant(.space))
         XCTAssertEqual(lexer.getNextToken(), .constant(.integer(180)))
         XCTAssertEqual(lexer.getNextToken(), .constant(.string("°")))

--- a/Tests/CookInSwiftTests/LexerTests.swift
+++ b/Tests/CookInSwiftTests/LexerTests.swift
@@ -289,7 +289,7 @@ class LexerTests: XCTestCase {
     }
     
     func testComments() {
-        let input = "// testing comments"
+        let input = "-- testing comments"
         let lexer = Lexer(input)
                 
         XCTAssertEqual(lexer.getNextToken(), .eol)
@@ -297,12 +297,12 @@ class LexerTests: XCTestCase {
     }
     
     func testSlashLast() {
-        let input = "onions /"
+        let input = "onions -"
         let lexer = Lexer(input)
         
         XCTAssertEqual(lexer.getNextToken(), .constant(.string("onions")))
         XCTAssertEqual(lexer.getNextToken(), .constant(.space))
-        XCTAssertEqual(lexer.getNextToken(), .constant(.string("/")))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("-")))
         XCTAssertEqual(lexer.getNextToken(), .eof)
     }
     
@@ -319,8 +319,7 @@ class LexerTests: XCTestCase {
         XCTAssertEqual(lexer.getNextToken(), .constant(.string("to")))
         XCTAssertEqual(lexer.getNextToken(), .constant(.space))
         XCTAssertEqual(lexer.getNextToken(), .constant(.integer(200)))
-        XCTAssertEqual(lexer.getNextToken(), .constant(.string("℃")))
-        XCTAssertEqual(lexer.getNextToken(), .constant(.string("/")))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("℃/")))
         XCTAssertEqual(lexer.getNextToken(), .constant(.string("Fan")))
         XCTAssertEqual(lexer.getNextToken(), .constant(.space))
         XCTAssertEqual(lexer.getNextToken(), .constant(.integer(180)))

--- a/Tests/CookInSwiftTests/ParserTests.swift
+++ b/Tests/CookInSwiftTests/ParserTests.swift
@@ -567,7 +567,7 @@ class ParserTests: XCTestCase {
     }
     
     func testComments() {
-        let recipe = "// testing comments"
+        let recipe = "-- testing comments"
         
         let result = try! Parser.parse(recipe) as! RecipeNode
                 
@@ -582,7 +582,7 @@ class ParserTests: XCTestCase {
     func testCommentsWithIngredients() {
         let recipe =
         """
-        // testing comments
+        -- testing comments
         @thyme{2%springs}
         """
         
@@ -600,7 +600,7 @@ class ParserTests: XCTestCase {
     func testCommentsAfterIngredients() {
         let recipe =
         """
-        @thyme{2%springs} // testing comments
+        @thyme{2%springs} -- testing comments
         """
         
         let result = try! Parser.parse(recipe) as! RecipeNode

--- a/Tests/CookInSwiftTests/SemanticAnalyzerTests.swift
+++ b/Tests/CookInSwiftTests/SemanticAnalyzerTests.swift
@@ -213,7 +213,7 @@ class SemanticAnalyzerTests: XCTestCase {
 
             Add the @flour{530%g, continue mixing until the dough is smooth and flour is well incorporated. (Dough should not stick to your hands.)
 
-            Keep the dough //covered until ready to use.
+            Keep the dough --covered until ready to use.
 
             Place @butter{%} into freezer. Cube @chicken > thighs{450%g} into small pieces. Chop @onion{1 really fine. Peel @potatoes{450%g} and cube into small pieces, place in bowl and cover with cold water, set aside.
 


### PR DESCRIPTION
Replaces old comment syntax `//` with `--`. Also adds support for block comments `[- comment text -]`.

Fixes: https://github.com/cooklang/CookInSwift/issues/7