### PR TITLE
Allow no units in timer

### DIFF
--- a/Sources/CookInSwift/Parser/Parser.swift
+++ b/Sources/CookInSwift/Parser/Parser.swift
@@ -359,17 +359,18 @@ public class Parser {
         let name = taggedName()
         eat(.braces(.left))
         var quantity = values()
-        eat(.percent)
-
         var units = ""
+        if currentToken == .percent {
+            eat(.percent)
 
-        do {
-            units = try stringUntilTerminator(terminators: [.braces(.right)])
-        } catch ParserError.terminatorNotFound {
-            print("Warning: expected '}' but got end of line")
-            return TimerNode(quantity: "", units: "", name: "Invalid timer syntax")
-        } catch {
-            fatalError("Unexpected exception")
+            do {
+                units = try stringUntilTerminator(terminators: [.braces(.right)])
+            } catch ParserError.terminatorNotFound {
+                print("Warning: expected '}' but got end of line")
+                return TimerNode(quantity: "", units: "", name: "Invalid timer syntax")
+            } catch {
+                fatalError("Unexpected exception")
+            }
         }
 
         eat(.braces(.right))

--- a/Tests/CookInSwiftTests/LexerTests.swift
+++ b/Tests/CookInSwiftTests/LexerTests.swift
@@ -491,17 +491,35 @@ class LexerTests: XCTestCase {
         XCTAssertEqual(lexer.getNextToken(), .eof)
     }
     
-    func tesTimer() {
+    func testTimer() {
         let input = "cook for ~{10%minutes}"
         let lexer = Lexer(input)
     
         XCTAssertEqual(lexer.getNextToken(), .constant(.string("cook")))
         XCTAssertEqual(lexer.getNextToken(), .constant(.space))
         XCTAssertEqual(lexer.getNextToken(), .constant(.string("for")))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.space))
         XCTAssertEqual(lexer.getNextToken(), .tilde)
         XCTAssertEqual(lexer.getNextToken(), .braces(.left))
         XCTAssertEqual(lexer.getNextToken(), .constant(.integer(10)))
         XCTAssertEqual(lexer.getNextToken(), .percent)
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("minutes")))
+        XCTAssertEqual(lexer.getNextToken(), .braces(.right))
+        XCTAssertEqual(lexer.getNextToken(), .eof)
+    }
+
+    func testBrokenTimer() {
+        let input = "cook for ~{10 minutes}"
+        let lexer = Lexer(input)
+
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("cook")))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.space))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.string("for")))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.space))
+        XCTAssertEqual(lexer.getNextToken(), .tilde)
+        XCTAssertEqual(lexer.getNextToken(), .braces(.left))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.integer(10)))
+        XCTAssertEqual(lexer.getNextToken(), .constant(.space))
         XCTAssertEqual(lexer.getNextToken(), .constant(.string("minutes")))
         XCTAssertEqual(lexer.getNextToken(), .braces(.right))
         XCTAssertEqual(lexer.getNextToken(), .eof)

--- a/Tests/CookInSwiftTests/ParserCanonicalTests.swift
+++ b/Tests/CookInSwiftTests/ParserCanonicalTests.swift
@@ -4,7 +4,7 @@
 //
 // don't edit this file
 //
-// version: 2
+// version: 4
 //
 
 import Foundation
@@ -418,27 +418,6 @@ class ParserCanonicalTests: XCTestCase {
             let steps: [StepNode] = [
                 StepNode(instructions: [
                     IngredientNode(name: "chilli", amount: AmountNode(quantity: 3, units: "items")),
-                ]),
-            ]
-
-            let metadata: [MetadataNode] = []
-
-            let node = RecipeNode(steps: steps, metadata: metadata)
-
-            XCTAssertEqual(result, node)
-        }
-    
-        func testIngridentImplicitQuantity() {
-            let recipe =
-                """
-                @chilli{%items}
-                """
-
-            let result = try! Parser.parse(recipe) as! RecipeNode
-
-            let steps: [StepNode] = [
-                StepNode(instructions: [
-                    IngredientNode(name: "chilli", amount: AmountNode(quantity: "", units: "items")),
                 ]),
             ]
 
@@ -893,28 +872,6 @@ class ParserCanonicalTests: XCTestCase {
             XCTAssertEqual(result, node)
         }
     
-        func testEmptyTimer() {
-            let recipe =
-                """
-                Fry for ~{%mins}
-                """
-
-            let result = try! Parser.parse(recipe) as! RecipeNode
-
-            let steps: [StepNode] = [
-                StepNode(instructions: [
-                    DirectionNode("Fry for "),
-                    TimerNode(quantity: 0, units: "mins", name: ""),
-                ]),
-            ]
-
-            let metadata: [MetadataNode] = []
-
-            let node = RecipeNode(steps: steps, metadata: metadata)
-
-            XCTAssertEqual(result, node)
-        }
-
         func testTimerWithName() {
             let recipe =
                 """

--- a/Tests/CookInSwiftTests/ParserTests.swift
+++ b/Tests/CookInSwiftTests/ParserTests.swift
@@ -15,4 +15,26 @@ class ParserTests: XCTestCase {
 //    TODO add tests for errors and edge-cases
 //    TODO spaces in all possible random places
 //    special symbols, quotes
+
+    func testTimerInteger() {
+        let recipe =
+            """
+            Fry for ~{10 minutes}
+            """
+
+        let result = try! Parser.parse(recipe) as! RecipeNode
+
+        let steps: [StepNode] = [
+            StepNode(instructions: [
+                DirectionNode("Fry for "),
+                TimerNode(quantity: "10 minutes", units: "", name: ""),
+            ]),
+        ]
+
+        let metadata: [MetadataNode] = []
+
+        let node = RecipeNode(steps: steps, metadata: metadata)
+
+        XCTAssertEqual(result, node)
+    }
 }


### PR DESCRIPTION
Don't crash when 

    Fry for ~{10 minutes}

and consider "10 minutes" as quantity.