### PR TITLE
Revise public API

### DIFF
--- a/Sources/CookInSwift/Parser/AST+Extensions.swift
+++ b/Sources/CookInSwift/Parser/AST+Extensions.swift
@@ -76,27 +76,16 @@ extension StepNode: Equatable {
     }
 }
 
-extension ValuesNode: Equatable {
-    public static func == (lhs: ValuesNode, rhs: ValuesNode) -> Bool {
-        for (l, r) in zip(lhs.values, rhs.values) {
-            if l.value != r.value {
-                return false
-            }
-        }
-
-        return true
+extension ValueNode: Equatable {
+    public static func == (lhs: ValueNode, rhs: ValueNode) -> Bool {
+        return lhs.value.value == rhs.value.value
     }
 }
 
-extension ValuesNode: Sequence {
-    public func makeIterator() -> IndexingIterator<[ConstantNode]> {
-        return values.makeIterator()
-    }
-}
 
-extension ValuesNode: CustomStringConvertible {
+extension ValueNode: CustomStringConvertible {
     public var description: String {
-        return map{ $0.value }.joined(separator: "|")
+        return value.description
     }
 }
 
@@ -122,15 +111,15 @@ extension TimerNode: Equatable {
 extension AST {
     var value: String {
         switch self {
-        case let value as ConstantNode:
+        case let v as ConstantNode:
 
-            switch value {
-            case let .string(value):
-                return "\(value)"
-            case let .integer(value):
-                return "\(value)"
-            case let .decimal(value):
-                return "\(value.cleanValue)"
+            switch v {
+            case let .string(v):
+                return "\(v)"
+            case let .integer(v):
+                return "\(v)"
+            case let .decimal(v):
+                return "\(v.cleanValue)"
             }
 
         case is RecipeNode:
@@ -147,11 +136,11 @@ extension AST {
             return "EQ: \(equipment.name)"
         case let timer as TimerNode:
             return "TIMER(\(timer.name)): \(timer.quantity) \(timer.units)"
-        case let v as ValuesNode:
+        case let v as ValueNode:
             return "\(v)"
         case let amount as AmountNode:
 //            TODO
-            switch amount.quantity.values.first {
+            switch amount.quantity.value {
             case let .integer(value):
                 return "\(value) \(amount.units.pluralize(value))"
             case let .decimal(value):
@@ -181,7 +170,7 @@ extension AST {
             return []
         case is TimerNode:
             return []
-        case is ValuesNode:
+        case is ValueNode:
             return []
         case is EquipmentNode:
             return []

--- a/Sources/CookInSwift/Parser/AST+Extensions.swift
+++ b/Sources/CookInSwift/Parser/AST+Extensions.swift
@@ -17,7 +17,7 @@ extension Decimal {
 }
 
 
-extension ConstantNode {
+extension ValueNode {
     init(_ value: Int) {
         self = .integer(value)
     }
@@ -32,7 +32,7 @@ extension ConstantNode {
 }
 
 
-extension ConstantNode: CustomStringConvertible {
+extension ValueNode: CustomStringConvertible {
     public var description: String {
         switch self {
         case let .integer(value):
@@ -45,8 +45,8 @@ extension ConstantNode: CustomStringConvertible {
     }
 }
 
-extension ConstantNode: Equatable {
-    public static func == (lhs: ConstantNode, rhs: ConstantNode) -> Bool {
+extension ValueNode: Equatable {
+    public static func == (lhs: ValueNode, rhs: ValueNode) -> Bool {
         switch (lhs, rhs) {
         case let (.integer(left), .integer(right)):
             return left == right
@@ -56,6 +56,8 @@ extension ConstantNode: Equatable {
             return left == Decimal(right)
         case let (.integer(left), .decimal(right)):
             return Decimal(left) == right
+        case let (.string(left), .string(right)):
+            return left == right
         case (.string(_), _):
             return false
         case (_, .string(_)):
@@ -73,19 +75,6 @@ extension RecipeNode: Equatable {
 extension StepNode: Equatable {
     public static func == (lhs: StepNode, rhs: StepNode) -> Bool {
         return lhs.instructions.map{ ($0.value ) }  == rhs.instructions.map{ ($0.value ) }
-    }
-}
-
-extension ValueNode: Equatable {
-    public static func == (lhs: ValueNode, rhs: ValueNode) -> Bool {
-        return lhs.value.value == rhs.value.value
-    }
-}
-
-
-extension ValueNode: CustomStringConvertible {
-    public var description: String {
-        return value.description
     }
 }
 
@@ -111,7 +100,7 @@ extension TimerNode: Equatable {
 extension AST {
     var value: String {
         switch self {
-        case let v as ConstantNode:
+        case let v as ValueNode:
 
             switch v {
             case let .string(v):
@@ -135,12 +124,10 @@ extension AST {
         case let equipment as EquipmentNode:
             return "EQ: \(equipment.name)"
         case let timer as TimerNode:
-            return "TIMER(\(timer.name)): \(timer.quantity) \(timer.units)"
-        case let v as ValueNode:
-            return "\(v)"
+            return "TIMER(\(timer.name)): \(timer.quantity) \(timer.units)"        
         case let amount as AmountNode:
 //            TODO
-            switch amount.quantity.value {
+            switch amount.quantity {
             case let .integer(value):
                 return "\(value) \(amount.units.pluralize(value))"
             case let .decimal(value):
@@ -156,7 +143,7 @@ extension AST {
 
     var children: [AST] {
         switch self {
-        case is ConstantNode:
+        case is ValueNode:
             return []
         case is String:
             return []
@@ -169,8 +156,6 @@ extension AST {
         case is IngredientNode:
             return []
         case is TimerNode:
-            return []
-        case is ValueNode:
             return []
         case is EquipmentNode:
             return []

--- a/Sources/CookInSwift/Parser/AST.swift
+++ b/Sources/CookInSwift/Parser/AST.swift
@@ -16,35 +16,36 @@ public enum ConstantNode: AST {
     case string(String)
 }
 
-public struct ValuesNode: AST {
-    var values: [ConstantNode]
+public struct ValueNode: AST {
+    var value: ConstantNode
 
-    init()  {
-        values = []
+    init() {
+//        TODO ???
+        value = ConstantNode("")
     }
 
-    init(_ value: ConstantNode)  {
-        values = [value]
+    init(_ v: ConstantNode)  {
+        value = v
     }
 
-    init(_ value: String) {
-        values = [ConstantNode(value)]
+    init(_ v: String) {
+        value = ConstantNode(v)
     }
 
-    init(_ value: Int) {
-        values = [ConstantNode(value)]
+    init(_ v: Int) {
+        value = ConstantNode(v)
     }
 
-    init(_ value: Decimal) {
-        values = [ConstantNode(value)]
+    init(_ v: Decimal) {
+        value = ConstantNode(v)
     }
 
-    mutating func add(_ value: ConstantNode) {
-        values.append(value)
+    mutating func add(_ v: ConstantNode) {
+        value = v
     }
 
     func isEmpty() -> Bool {
-        return values.isEmpty
+        return value.isEmpty
     }
 }
 
@@ -61,30 +62,30 @@ struct DirectionNode: AST {
 
 struct MetadataNode: AST {
     let key: String
-    let value: ValuesNode
+    let value: ValueNode
 
-    init(_ key: String, _ value: ValuesNode) {
+    init(_ key: String, _ value: ValueNode) {
         self.key = key
         self.value = value
     }
 
     init(_ key: String, _ value: ConstantNode) {
         self.key = key
-        self.value = ValuesNode(value)
+        self.value = ValueNode(value)
     }
 
     init(_ key: String, _ value: String) {
-        self.value = ValuesNode(ConstantNode.string(value))
+        self.value = ValueNode(ConstantNode.string(value))
         self.key = key
     }
 
     init(_ key: String, _ value: Int) {
-        self.value = ValuesNode(ConstantNode.integer(value))
+        self.value = ValueNode(ConstantNode.integer(value))
         self.key = key
     }
 
     init(_ key: String, _ value: Decimal) {
-        self.value = ValuesNode(ConstantNode.decimal(value))
+        self.value = ValueNode(ConstantNode.decimal(value))
         self.key = key
     }
 
@@ -92,31 +93,31 @@ struct MetadataNode: AST {
 
 
 struct AmountNode: AST {
-    let quantity: ValuesNode
+    let quantity: ValueNode
     let units: String
 
-    init(quantity: ValuesNode, units: String = "") {
+    init(quantity: ValueNode, units: String = "") {
         self.quantity = quantity
         self.units = units
     }
 
     init(quantity: ConstantNode, units: String = "") {
-        self.quantity = ValuesNode(quantity)
+        self.quantity = ValueNode(quantity)
         self.units = units
     }
 
     init(quantity: String, units: String = "") {
-        self.quantity = ValuesNode(ConstantNode.string(quantity))
+        self.quantity = ValueNode(ConstantNode.string(quantity))
         self.units = units
     }
 
     init(quantity: Int, units: String = "") {
-        self.quantity = ValuesNode(ConstantNode.integer(quantity))
+        self.quantity = ValueNode(ConstantNode.integer(quantity))
         self.units = units
     }
 
     init(quantity: Decimal, units: String = "") {
-        self.quantity = ValuesNode(ConstantNode.decimal(quantity))
+        self.quantity = ValueNode(ConstantNode.decimal(quantity))
         self.units = units
     }
 
@@ -134,45 +135,45 @@ struct IngredientNode: AST {
 
 struct EquipmentNode: AST {
     let name: String
-    let quantity: ValuesNode?
+    let quantity: ValueNode?
 
-    init(name: String, quantity: ValuesNode? = nil) {
+    init(name: String, quantity: ValueNode? = nil) {
         self.name = name
         self.quantity = quantity
     }
 }
 
 struct TimerNode: AST {
-    let quantity: ValuesNode
+    let quantity: ValueNode
     let units: String
     let name: String
 
-    init(quantity: ValuesNode, units: String, name: String = "") {
+    init(quantity: ValueNode, units: String, name: String = "") {
         self.quantity = quantity
         self.units = units
         self.name = name
     }
 
     init(quantity: ConstantNode, units: String, name: String = "") {
-        self.quantity = ValuesNode(quantity)
+        self.quantity = ValueNode(quantity)
         self.units = units
         self.name = name
     }
 
     init(quantity: String, units: String, name: String = "") {
-        self.quantity = ValuesNode(ConstantNode.string(quantity))
+        self.quantity = ValueNode(ConstantNode.string(quantity))
         self.units = units
         self.name = name
     }
 
     init(quantity: Int, units: String, name: String = "") {
-        self.quantity = ValuesNode(ConstantNode.integer(quantity))
+        self.quantity = ValueNode(ConstantNode.integer(quantity))
         self.units = units
         self.name = name
     }
 
     init(quantity: Decimal, units: String, name: String = "") {
-        self.quantity = ValuesNode(ConstantNode.decimal(quantity))
+        self.quantity = ValueNode(ConstantNode.decimal(quantity))
         self.units = units
         self.name = name
     }

--- a/Sources/CookInSwift/Parser/AST.swift
+++ b/Sources/CookInSwift/Parser/AST.swift
@@ -10,43 +10,10 @@ import Foundation
 
 public protocol AST {}
 
-public enum ConstantNode: AST {
+public enum ValueNode: AST {
     case integer(Int)
     case decimal(Decimal)
     case string(String)
-}
-
-public struct ValueNode: AST {
-    var value: ConstantNode
-
-    init() {
-//        TODO ???
-        value = ConstantNode("")
-    }
-
-    init(_ v: ConstantNode)  {
-        value = v
-    }
-
-    init(_ v: String) {
-        value = ConstantNode(v)
-    }
-
-    init(_ v: Int) {
-        value = ConstantNode(v)
-    }
-
-    init(_ v: Decimal) {
-        value = ConstantNode(v)
-    }
-
-    mutating func add(_ v: ConstantNode) {
-        value = v
-    }
-
-    func isEmpty() -> Bool {
-        return value.isEmpty
-    }
 }
 
 struct DirectionNode: AST {
@@ -58,8 +25,6 @@ struct DirectionNode: AST {
 }
 
 
-
-
 struct MetadataNode: AST {
     let key: String
     let value: ValueNode
@@ -69,23 +34,18 @@ struct MetadataNode: AST {
         self.value = value
     }
 
-    init(_ key: String, _ value: ConstantNode) {
-        self.key = key
-        self.value = ValueNode(value)
-    }
-
     init(_ key: String, _ value: String) {
-        self.value = ValueNode(ConstantNode.string(value))
+        self.value = ValueNode.string(value)
         self.key = key
     }
 
     init(_ key: String, _ value: Int) {
-        self.value = ValueNode(ConstantNode.integer(value))
+        self.value = ValueNode.integer(value)
         self.key = key
     }
 
     init(_ key: String, _ value: Decimal) {
-        self.value = ValueNode(ConstantNode.decimal(value))
+        self.value = ValueNode.decimal(value)
         self.key = key
     }
 
@@ -101,23 +61,18 @@ struct AmountNode: AST {
         self.units = units
     }
 
-    init(quantity: ConstantNode, units: String = "") {
-        self.quantity = ValueNode(quantity)
-        self.units = units
-    }
-
     init(quantity: String, units: String = "") {
-        self.quantity = ValueNode(ConstantNode.string(quantity))
+        self.quantity = ValueNode.string(quantity)
         self.units = units
     }
 
     init(quantity: Int, units: String = "") {
-        self.quantity = ValueNode(ConstantNode.integer(quantity))
+        self.quantity = ValueNode.integer(quantity)
         self.units = units
     }
 
     init(quantity: Decimal, units: String = "") {
-        self.quantity = ValueNode(ConstantNode.decimal(quantity))
+        self.quantity = ValueNode.decimal(quantity)
         self.units = units
     }
 
@@ -154,26 +109,20 @@ struct TimerNode: AST {
         self.name = name
     }
 
-    init(quantity: ConstantNode, units: String, name: String = "") {
-        self.quantity = ValueNode(quantity)
-        self.units = units
-        self.name = name
-    }
-
     init(quantity: String, units: String, name: String = "") {
-        self.quantity = ValueNode(ConstantNode.string(quantity))
+        self.quantity = ValueNode.string(quantity)
         self.units = units
         self.name = name
     }
 
     init(quantity: Int, units: String, name: String = "") {
-        self.quantity = ValueNode(ConstantNode.integer(quantity))
+        self.quantity = ValueNode.integer(quantity)
         self.units = units
         self.name = name
     }
 
     init(quantity: Decimal, units: String, name: String = "") {
-        self.quantity = ValueNode(ConstantNode.decimal(quantity))
+        self.quantity = ValueNode.decimal(quantity)
         self.units = units
         self.name = name
     }

--- a/Sources/CookInSwift/Parser/Parser.swift
+++ b/Sources/CookInSwift/Parser/Parser.swift
@@ -148,8 +148,8 @@ public class Parser {
     /**
 
      */
-    private func values() -> ValueNode {
-        var v = ValueNode()
+    private func values(defaultValue: ValueNode) -> ValueNode {
+        var v = defaultValue
 
         var strategy: QuantityParseStrategy = .string
         var i = tokenIndex
@@ -189,16 +189,16 @@ public class Parser {
             switch currentToken {
 
             case let .constant(.decimal(value)):
-                v.add(ConstantNode.decimal(value))
+                v = ValueNode.decimal(value)
                 eat(.constant(.decimal(value)))
 
             case let .constant(.integer(value)):
                 eat(.constant(.integer(value)))
-                v.add(ConstantNode.integer(value))
+                v = ValueNode.integer(value)
 
             case let .constant(.fractional((n, d))):
                 eat(.constant(.fractional((n, d))))
-                v.add(ConstantNode.decimal(Decimal(n) / Decimal(d)))
+                v = ValueNode.decimal(Decimal(n) / Decimal(d))
 
             default:
                 if !(currentToken == .braces(.right) || currentToken == .percent) {
@@ -218,7 +218,7 @@ public class Parser {
             }
 
             if value != "" {
-                v.add(ConstantNode.string(value))
+                v = ValueNode.string(value)
             }
         }
 
@@ -233,7 +233,7 @@ public class Parser {
     private func amount() throws -> AmountNode {
         eat(.braces(.left))
 
-        var q = values()
+        var q = values(defaultValue: ValueNode.string(""))
 
         var units = ""
 
@@ -245,11 +245,9 @@ public class Parser {
 
         eat(.braces(.right))
 
-        if q.isEmpty() {
+        if q.value == "" {
             if units.isEmpty {
-                q.add(ConstantNode.string("some"))
-            } else {
-                q.add(ConstantNode.string(""))
+                q = ValueNode.string("some")
             }
         }
 
@@ -358,7 +356,7 @@ public class Parser {
         eat(.tilde)
         let name = taggedName()
         eat(.braces(.left))
-        var quantity = values()
+        let quantity = values(defaultValue: ValueNode.integer(0))
         var units = ""
         if currentToken == .percent {
             eat(.percent)
@@ -374,10 +372,6 @@ public class Parser {
         }
 
         eat(.braces(.right))
-
-        if quantity.isEmpty() {
-            quantity.add(ConstantNode.integer(0))
-        }
 
         return TimerNode(quantity: quantity, units: units, name: name)
     }

--- a/Sources/CookInSwift/Parser/Parser.swift
+++ b/Sources/CookInSwift/Parser/Parser.swift
@@ -148,8 +148,8 @@ public class Parser {
     /**
 
      */
-    private func values() -> ValuesNode {
-        var v = ValuesNode()
+    private func values() -> ValueNode {
+        var v = ValueNode()
 
         var strategy: QuantityParseStrategy = .string
         var i = tokenIndex

--- a/Sources/CookInSwift/Semantic Analyzer/Helpers.swift
+++ b/Sources/CookInSwift/Semantic Analyzer/Helpers.swift
@@ -1,0 +1,22 @@
+//
+//  File.swift
+//  
+//
+//  Created by Alexey Dubovskoy on 07/03/2022.
+//
+
+import Foundation
+
+public func mergeIngredientTables(_ left: IngredientTable, _ right: IngredientTable) -> IngredientTable {
+    var result = IngredientTable()
+
+    for (name, amounts) in left.ingredients {
+        result.add(name: name, amounts: amounts)
+    }
+
+    for (name, amounts) in right.ingredients {
+        result.add(name: name, amounts: amounts)
+    }
+
+    return result
+}

--- a/Sources/CookInSwift/Semantic Analyzer/IngredientModel+Extentions.swift
+++ b/Sources/CookInSwift/Semantic Analyzer/IngredientModel+Extentions.swift
@@ -20,24 +20,6 @@ extension IngredientTable: CustomStringConvertible {
     }
 }
 
-public extension IngredientTable {
-    static func + (left: IngredientTable, right: IngredientTable) -> IngredientTable {
-        var result = IngredientTable()
-
-        for (name, amounts) in left.ingredients {
-            result.add(name: name, amounts: amounts)
-        }
-
-        for (name, amounts) in right.ingredients {
-            result.add(name: name, amounts: amounts)
-        }
-
-        return result
-    }
-}
-
-
-
 extension IngredientAmount: CustomStringConvertible {
     public var description: String {
         if units == "" {

--- a/Sources/CookInSwift/Semantic Analyzer/IngredientModel+Extentions.swift
+++ b/Sources/CookInSwift/Semantic Analyzer/IngredientModel+Extentions.swift
@@ -22,7 +22,7 @@ extension IngredientTable: CustomStringConvertible {
 
 public extension IngredientTable {
     static func + (left: IngredientTable, right: IngredientTable) -> IngredientTable {
-        let result = IngredientTable()
+        var result = IngredientTable()
 
         for (name, amounts) in left.ingredients {
             result.add(name: name, amounts: amounts)

--- a/Sources/CookInSwift/Semantic Analyzer/IngredientModel+Extentions.swift
+++ b/Sources/CookInSwift/Semantic Analyzer/IngredientModel+Extentions.swift
@@ -66,8 +66,8 @@ extension IngredientAmountCollection {
         private var _i1: Array<IngredientAmount>.Iterator , _i2: Array<IngredientAmount>.Iterator
 
         fileprivate init(_ amountsCountable: [String: Decimal], _ amountsUncountable: [String: String]) {
-            _i1 = amountsCountable.map{ IngredientAmount(ConstantNode.decimal($1), $0) }.makeIterator()
-            _i2 = amountsUncountable.map{ IngredientAmount(ConstantNode.string($1), $0) }.makeIterator()
+            _i1 = amountsCountable.map{ IngredientAmount(ValueNode.decimal($1), $0) }.makeIterator()
+            _i2 = amountsUncountable.map{ IngredientAmount(ValueNode.string($1), $0) }.makeIterator()
         }
     }
 }

--- a/Sources/CookInSwift/Semantic Analyzer/IngredientModel+Extentions.swift
+++ b/Sources/CookInSwift/Semantic Analyzer/IngredientModel+Extentions.swift
@@ -22,14 +22,39 @@ extension IngredientTable: CustomStringConvertible {
 
 extension IngredientAmount: CustomStringConvertible {
     public var description: String {
-        if units == "" {
-            return quantity.value
-        } else {
-            if let v = Int(quantity.value) {
-                return "\(quantity.value) \(units.pluralize(v))"
+        switch quantity {
+        case let value as Decimal:
+            // when summing up quantities converted to Decimal in IngredientsTable
+            // here we want to check if value can be converted back to integer before representation
+            if let v = Int("\(value)") {
+                if units == "" {
+                    return "\(value)"
+                } else {
+                    return "\(value) \(units.pluralize(v))"
+                }
             } else {
-                return "\(quantity.value) \(units.pluralize(2))"
+                if units == "" {
+                    return "\(value.cleanValue)"
+                } else {
+                    return "\(value.cleanValue) \(units.pluralize(2))"
+                }
             }
+        case is String:
+            if units == "" {
+                return "\(quantity)"
+            } else {
+                return "\(quantity) \(units.pluralize(2))"
+            }
+
+        case let value as Int:
+            if units == "" {
+                return "\(value)"
+            } else {
+                return "\(value) \(units.pluralize(value))"
+            }
+
+        default:
+            return ""
         }
     }
 }
@@ -48,8 +73,8 @@ extension IngredientAmountCollection {
         private var _i1: Array<IngredientAmount>.Iterator , _i2: Array<IngredientAmount>.Iterator
 
         fileprivate init(_ amountsCountable: [String: Decimal], _ amountsUncountable: [String: String]) {
-            _i1 = amountsCountable.map{ IngredientAmount(ValueNode.decimal($1), $0) }.makeIterator()
-            _i2 = amountsUncountable.map{ IngredientAmount(ValueNode.string($1), $0) }.makeIterator()
+            _i1 = amountsCountable.map{ IngredientAmount($1, $0) }.makeIterator()
+            _i2 = amountsUncountable.map{ IngredientAmount(String($1), $0) }.makeIterator()
         }
     }
 }

--- a/Sources/CookInSwift/Semantic Analyzer/IngredientModel.swift
+++ b/Sources/CookInSwift/Semantic Analyzer/IngredientModel.swift
@@ -10,21 +10,21 @@ import Foundation
 
 public class IngredientAmount {
 //    TODO remove refs to internal ValuesNode
-    public var quantity: ValuesNode
+    public var quantity: ValueNode
     public var units: String
 
-    init(_ quantity: ValuesNode, _ units: String) {
+    init(_ quantity: ValueNode, _ units: String) {
         self.quantity = quantity
         self.units = units
     }
 
     init(_ quantity: ConstantNode, _ units: String) {
-        self.quantity = ValuesNode(quantity)
+        self.quantity = ValueNode(quantity)
         self.units = units
     }
 
     init(_ quantity: Int, _ units: String) {
-        self.quantity = ValuesNode(quantity)
+        self.quantity = ValueNode(quantity)
         self.units = units
     }
 }
@@ -38,15 +38,13 @@ public class IngredientAmountCollection {
         let units = amount.units.singularize
 
         // TODO
-        switch amount.quantity.values.first {
+        switch amount.quantity.value {
         case let .integer(value):
             amountsCountable[units] = amountsCountable[units, default: 0] + Decimal(value)
         case let .decimal(value):
             amountsCountable[units] = amountsCountable[units, default: 0] + value
         case let .string(value):
-            amountsUncountable[amount.units] = value
-        case .none:
-            fatalError("Shite!")
+            amountsUncountable[amount.units] = value        
         }
     }
 }

--- a/Sources/CookInSwift/Semantic Analyzer/IngredientModel.swift
+++ b/Sources/CookInSwift/Semantic Analyzer/IngredientModel.swift
@@ -16,12 +16,7 @@ public struct IngredientAmount {
     init(_ quantity: ValueNode, _ units: String) {
         self.quantity = quantity
         self.units = units
-    }
-
-    init(_ quantity: ConstantNode, _ units: String) {
-        self.quantity = ValueNode(quantity)
-        self.units = units
-    }
+    }  
 
     init(_ quantity: Int, _ units: String) {
         self.quantity = ValueNode(quantity)
@@ -38,7 +33,7 @@ public struct IngredientAmountCollection {
         let units = amount.units.singularize
 
         // TODO
-        switch amount.quantity.value {
+        switch amount.quantity {
         case let .integer(value):
             amountsCountable[units] = amountsCountable[units, default: 0] + Decimal(value)
         case let .decimal(value):

--- a/Sources/CookInSwift/Semantic Analyzer/IngredientModel.swift
+++ b/Sources/CookInSwift/Semantic Analyzer/IngredientModel.swift
@@ -7,19 +7,34 @@
 
 import Foundation
 
+public protocol ValueProtocol {}
+
+extension String:ValueProtocol{}
+extension Int:ValueProtocol{}
+extension Decimal:ValueProtocol{}
 
 public struct IngredientAmount {
 //    TODO remove refs to internal ValuesNode
-    public var quantity: ValueNode
+    public var quantity: ValueProtocol
     public var units: String
 
-    init(_ quantity: ValueNode, _ units: String) {
+    init(_ quantity: ValueProtocol, _ units: String) {
         self.quantity = quantity
         self.units = units
-    }  
+    }
 
     init(_ quantity: Int, _ units: String) {
-        self.quantity = ValueNode(quantity)
+        self.quantity = quantity
+        self.units = units
+    }
+
+    init(_ quantity: Decimal, _ units: String) {
+        self.quantity = quantity
+        self.units = units
+    }
+
+    init(_ quantity: String, _ units: String) {
+        self.quantity = quantity
         self.units = units
     }
 }
@@ -33,13 +48,15 @@ public struct IngredientAmountCollection {
         let units = amount.units.singularize
 
         // TODO
-        switch amount.quantity {
-        case let .integer(value):
+        switch amount.quantity.self {
+        case let value as Int:
             amountsCountable[units] = amountsCountable[units, default: 0] + Decimal(value)
-        case let .decimal(value):
+        case let value as Decimal:
             amountsCountable[units] = amountsCountable[units, default: 0] + value
-        case let .string(value):
+        case let value as String:
             amountsUncountable[amount.units] = value
+        default:
+            fatalError("Unrecognised value type")
         }
     }
 }

--- a/Sources/CookInSwift/Semantic Analyzer/IngredientModel.swift
+++ b/Sources/CookInSwift/Semantic Analyzer/IngredientModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 
-public class IngredientAmount {
+public struct IngredientAmount {
 //    TODO remove refs to internal ValuesNode
     public var quantity: ValueNode
     public var units: String
@@ -30,11 +30,11 @@ public class IngredientAmount {
 }
 
 
-public class IngredientAmountCollection {
+public struct IngredientAmountCollection {
     var amountsCountable: [String: Decimal] = [:]
     var amountsUncountable: [String: String] = [:]
 
-    func add(_ amount: IngredientAmount) {
+    mutating func add(_ amount: IngredientAmount) {
         let units = amount.units.singularize
 
         // TODO
@@ -44,18 +44,18 @@ public class IngredientAmountCollection {
         case let .decimal(value):
             amountsCountable[units] = amountsCountable[units, default: 0] + value
         case let .string(value):
-            amountsUncountable[amount.units] = value        
+            amountsUncountable[amount.units] = value
         }
     }
 }
 
-public class IngredientTable {
+public struct IngredientTable {
     public var ingredients: [String: IngredientAmountCollection] = [:]
 
     public init() {
     }
 
-    public func add(name: String, amount: IngredientAmount) {
+    mutating public func add(name: String, amount: IngredientAmount) {
         if ingredients[name] == nil {
             ingredients[name] = IngredientAmountCollection()
         }
@@ -63,7 +63,7 @@ public class IngredientTable {
         ingredients[name]?.add(amount)
     }
 
-    public func add(name: String, amounts: IngredientAmountCollection) {
+    mutating public func add(name: String, amounts: IngredientAmountCollection) {
         amounts.forEach {
             add(name: name, amount: $0)
         }

--- a/Sources/CookInSwift/Semantic Analyzer/SemanticAnalyzer.swift
+++ b/Sources/CookInSwift/Semantic Analyzer/SemanticAnalyzer.swift
@@ -9,12 +9,12 @@
 import Foundation
 
 public class SemanticAnalyzer: Visitor {
-    private var currentStep: SemanticStep = SemanticStep()
-    private var currentRecipe: SemanticRecipe = SemanticRecipe()
+    private var currentStep: Step = Step()
+    private var currentRecipe: Recipe = Recipe()
 
     public init() {}
 
-    public func analyze(node: AST) -> SemanticRecipe {
+    public func analyze(node: AST) -> Recipe {
         visit(node: node)
         
         return currentRecipe
@@ -44,7 +44,7 @@ public class SemanticAnalyzer: Visitor {
             visit(step: step)
 
             currentRecipe.addStep(currentStep)
-            currentStep = SemanticStep()
+            currentStep = Step()
         }
     }
     

--- a/Sources/CookInSwift/Semantic Analyzer/SemanticModel+Extensions.swift
+++ b/Sources/CookInSwift/Semantic Analyzer/SemanticModel+Extensions.swift
@@ -10,15 +10,15 @@ import Foundation
 
 
 
-extension SemanticRecipe: Equatable {
-    public static func == (lhs: SemanticRecipe, rhs: SemanticRecipe) -> Bool {
+extension Recipe: Equatable {
+    public static func == (lhs: Recipe, rhs: Recipe) -> Bool {
         return lhs.steps == rhs.steps && lhs.metadata == rhs.metadata
     }
 }
 
 
 
-extension SemanticStep: CustomStringConvertible {
+extension Step: CustomStringConvertible {
     public var description: String {
         return """
         Directions:
@@ -29,8 +29,8 @@ extension SemanticStep: CustomStringConvertible {
     }
 }
 
-extension SemanticStep: Equatable {
-    public static func ==(lhs: SemanticStep, rhs: SemanticStep) -> Bool {
+extension Step: Equatable {
+    public static func ==(lhs: Step, rhs: Step) -> Bool {
         // TODO too expensive
         return lhs.directions.map { $0.description }.joined() == rhs.directions.map { $0.description }.joined()
     }
@@ -52,13 +52,13 @@ extension TextItem: Equatable {
 
 
 
-extension ParsedEquipment: Equatable {
-    public static func == (lhs: ParsedEquipment, rhs: ParsedEquipment) -> Bool {
+extension Equipment: Equatable {
+    public static func == (lhs: Equipment, rhs: Equipment) -> Bool {
         return lhs.name == rhs.name
     }
 }
 
-extension ParsedEquipment: CustomStringConvertible {
+extension Equipment: CustomStringConvertible {
     public var description: String {
         return name
     }
@@ -67,13 +67,13 @@ extension ParsedEquipment: CustomStringConvertible {
 
 
 
-extension ParsedTimer: Equatable {
-    public static func == (lhs: ParsedTimer, rhs: ParsedTimer) -> Bool {
+extension Timer: Equatable {
+    public static func == (lhs: Timer, rhs: Timer) -> Bool {
         return lhs.quantity == rhs.quantity
     }
 }
 
-extension ParsedTimer: CustomStringConvertible {
+extension Timer: CustomStringConvertible {
     public var description: String {
         if let v = Int(quantity.value) {
             return "\(quantity.value) \(units.pluralize(v))"
@@ -85,14 +85,14 @@ extension ParsedTimer: CustomStringConvertible {
 
 
 
-extension ParsedIngredient: Equatable {
-    public static func == (lhs: ParsedIngredient, rhs: ParsedIngredient) -> Bool {
+extension Ingredient: Equatable {
+    public static func == (lhs: Ingredient, rhs: Ingredient) -> Bool {
         return lhs.name == rhs.name
     }
 }
 
 
-extension ParsedIngredient: CustomStringConvertible {
+extension Ingredient: CustomStringConvertible {
     public var description: String {
         return name
     }

--- a/Sources/CookInSwift/Semantic Analyzer/SemanticModel.swift
+++ b/Sources/CookInSwift/Semantic Analyzer/SemanticModel.swift
@@ -47,7 +47,18 @@ public struct Step {
 
     mutating func addIngredient(_ ingredient: IngredientNode) {
         let name = ingredient.name
-        let amount = IngredientAmount(ingredient.amount.quantity, ingredient.amount.units)
+        var quantity: ValueProtocol
+
+        switch ingredient.amount.quantity {
+        case let .integer(value):
+            quantity = value
+        case let .decimal(value):
+            quantity = value
+        case let .string(value):
+            quantity = value
+        }
+
+        let amount = IngredientAmount(quantity, ingredient.amount.units)
         let ingredient = Ingredient(name, amount)
 
         ingredientsTable.add(name: name, amount: amount)

--- a/Sources/CookInSwift/Semantic Analyzer/SemanticModel.swift
+++ b/Sources/CookInSwift/Semantic Analyzer/SemanticModel.swift
@@ -8,23 +8,22 @@
 
 import Foundation
 
-public class SemanticRecipe: Identifiable {
-    public let id = UUID()
+public struct Recipe {
     public var ingredientsTable: IngredientTable = IngredientTable()
-    public var steps: [SemanticStep] = []
-    public var equipment: [ParsedEquipment] = []
+    public var steps: [Step] = []
+    public var equipment: [Equipment] = []
     public var metadata: [String: String] = [:]
 
-    func addStep(_ step: SemanticStep) {
+    mutating func addStep(_ step: Step) {
         steps.append(step)
         ingredientsTable = ingredientsTable + step.ingredientsTable
     }
 
-    func addEquipment(_ e: EquipmentNode) {
-        equipment.append(ParsedEquipment(e.name))
+    mutating func addEquipment(_ e: EquipmentNode) {
+        equipment.append(Equipment(e.name))
     }
 
-    func addMetadata(_ m: [MetadataNode]) {
+    mutating func addMetadata(_ m: [MetadataNode]) {
         m.forEach{ item in
             metadata[item.key] = item.value.description
         }
@@ -32,44 +31,43 @@ public class SemanticRecipe: Identifiable {
 
 }
 
-public class SemanticStep: Identifiable {
-    public let id = UUID()
+public struct Step {
     public var ingredientsTable: IngredientTable = IngredientTable()
     public var directions: [DirectionItem] = []
-    public var timers: [ParsedTimer] = []
-    public var equipments: [ParsedEquipment] = []
+    public var timers: [Timer] = []
+    public var equipments: [Equipment] = []
 
-    func addIngredient(_ ingredient: IngredientNode) {
+    mutating func addIngredient(_ ingredient: IngredientNode) {
         let name = ingredient.name
         let amount = IngredientAmount(ingredient.amount.quantity, ingredient.amount.units)
-        let ingredient = ParsedIngredient(name, amount)
+        let ingredient = Ingredient(name, amount)
 
         ingredientsTable.add(name: name, amount: amount)
         directions.append(ingredient)
     }
 
-    func addTimer(_ timer: TimerNode) {
-        let timer = ParsedTimer(timer.quantity, timer.units)
+    mutating func addTimer(_ timer: TimerNode) {
+        let timer = Timer(timer.quantity, timer.units)
 
         timers.append(timer)
         directions.append(timer)
     }
 
-    func addText(_ direction: DirectionNode) {
+    mutating func addText(_ direction: DirectionNode) {
         let text = TextItem(direction.value.description)
 
         directions.append(text)
     }
 
-    func addEquipment(_ equipment: EquipmentNode) {
-        let equipment = ParsedEquipment(equipment.name)
+    mutating func addEquipment(_ equipment: EquipmentNode) {
+        let equipment = Equipment(equipment.name)
 
         equipments.append(equipment)
         directions.append(equipment)
     }
 }
 
-public class TextItem: DirectionItem {
+public struct TextItem: DirectionItem {
     public var value: String
 
     init(_ value: String) {
@@ -78,7 +76,7 @@ public class TextItem: DirectionItem {
 }
 
 
-public class ParsedIngredient: DirectionItem {
+public struct Ingredient: DirectionItem {
     public var name: String
     public var amount: IngredientAmount
 
@@ -88,7 +86,7 @@ public class ParsedIngredient: DirectionItem {
     }
 }
 
-public class ParsedEquipment: DirectionItem {
+public struct Equipment: DirectionItem {
     public var name: String
 
     init(_ name: String) {
@@ -96,7 +94,7 @@ public class ParsedEquipment: DirectionItem {
     }
 }
 
-public class ParsedTimer: DirectionItem {
+public struct Timer: DirectionItem {
 //    TODO remove refs to internal ValuesNode
     public var quantity: ValueNode
     public var units: String

--- a/Sources/CookInSwift/Semantic Analyzer/SemanticModel.swift
+++ b/Sources/CookInSwift/Semantic Analyzer/SemanticModel.swift
@@ -16,7 +16,7 @@ public struct Recipe {
 
     mutating func addStep(_ step: Step) {
         steps.append(step)
-        ingredientsTable = mergeIngredientTables(ingredientsTable, step.ingredientsTable) 
+        ingredientsTable = mergeIngredientTables(ingredientsTable, step.ingredientsTable)
     }
 
     mutating func addEquipment(_ e: EquipmentNode) {
@@ -27,6 +27,14 @@ public struct Recipe {
         m.forEach{ item in
             metadata[item.key] = item.value.description
         }
+    }
+
+    public static func from(text: String) throws -> Recipe {
+        let analyzer = SemanticAnalyzer()
+
+        let node = try Parser.parse(text) as! RecipeNode
+
+        return analyzer.analyze(node: node)
     }
 
 }

--- a/Sources/CookInSwift/Semantic Analyzer/SemanticModel.swift
+++ b/Sources/CookInSwift/Semantic Analyzer/SemanticModel.swift
@@ -16,7 +16,7 @@ public struct Recipe {
 
     mutating func addStep(_ step: Step) {
         steps.append(step)
-        ingredientsTable = ingredientsTable + step.ingredientsTable
+        ingredientsTable = mergeIngredientTables(ingredientsTable, step.ingredientsTable) 
     }
 
     mutating func addEquipment(_ e: EquipmentNode) {

--- a/Sources/CookInSwift/Semantic Analyzer/SemanticModel.swift
+++ b/Sources/CookInSwift/Semantic Analyzer/SemanticModel.swift
@@ -98,27 +98,27 @@ public class ParsedEquipment: DirectionItem {
 
 public class ParsedTimer: DirectionItem {
 //    TODO remove refs to internal ValuesNode
-    public var quantity: ValuesNode
+    public var quantity: ValueNode
     public var units: String
 
-    init(_ quantity: ValuesNode, _ units: String) {
+    init(_ quantity: ValueNode, _ units: String) {
         self.quantity = quantity
         self.units = units
     }
 
 //    TODO figure out how to make it DRY
     init(_ quantity: Int, _ units: String) {
-        self.quantity = ValuesNode(quantity)
+        self.quantity = ValueNode(quantity)
         self.units = units
     }
 
     init(_ quantity: String, _ units: String) {
-        self.quantity = ValuesNode(quantity)
+        self.quantity = ValueNode(quantity)
         self.units = units
     }
 
     init(_ quantity: Decimal, _ units: String) {
-        self.quantity = ValuesNode(quantity)
+        self.quantity = ValueNode(quantity)
         self.units = units
     }
 }

--- a/Tests/CookInSwiftTests/IngredientModelTests.swift
+++ b/Tests/CookInSwiftTests/IngredientModelTests.swift
@@ -14,12 +14,12 @@ import XCTest
 class IngredientModelTests: XCTestCase {
 
     func testIngredientTableAddition() {
-        let table1 = IngredientTable()
+        var table1 = IngredientTable()
 
         table1.add(name: "chilli", amount: IngredientAmount(ConstantNode.integer(3), "items"))
         table1.add(name: "chilli", amount: IngredientAmount(ConstantNode.integer(1), "medium"))
 
-        let table2 = IngredientTable()
+        var table2 = IngredientTable()
 
         table2.add(name: "chilli", amount: IngredientAmount(ConstantNode.integer(5), "items"))
         table1.add(name: "chilli", amount: IngredientAmount(ConstantNode.integer(3), "small"))
@@ -28,7 +28,7 @@ class IngredientModelTests: XCTestCase {
     }
 
     func testSameUnitsAndType() {
-        let collection = IngredientAmountCollection()
+        var collection = IngredientAmountCollection()
         
         collection.add(IngredientAmount(ConstantNode.integer(1), "g"))
         collection.add(IngredientAmount(ConstantNode.integer(3), "g"))
@@ -38,7 +38,7 @@ class IngredientModelTests: XCTestCase {
     }
     
     func testDifferentUnits() {
-        let collection = IngredientAmountCollection()
+        var collection = IngredientAmountCollection()
         
         collection.add(IngredientAmount(ConstantNode.integer(50), "g"))
         collection.add(IngredientAmount(ConstantNode.integer(50), "g"))
@@ -49,7 +49,7 @@ class IngredientModelTests: XCTestCase {
     }
     
     func testDifferenQuantityTypes() {
-        let collection = IngredientAmountCollection()
+        var collection = IngredientAmountCollection()
                 
         collection.add(IngredientAmount(ConstantNode.integer(500), "g"))
         collection.add(IngredientAmount(ConstantNode.decimal(1.5), "kg"))
@@ -60,7 +60,7 @@ class IngredientModelTests: XCTestCase {
     }
     
     func testFractionsQuantityTypes() {
-        let collection = IngredientAmountCollection()
+        var collection = IngredientAmountCollection()
                 
         collection.add(IngredientAmount(ConstantNode.decimal(0.5), "cup"))
         collection.add(IngredientAmount(ConstantNode.integer(1), "cup"))
@@ -70,7 +70,7 @@ class IngredientModelTests: XCTestCase {
     }
 
     func testFractionsQuantityDecimalTypes() {
-        let collection = IngredientAmountCollection()
+        var collection = IngredientAmountCollection()
 
         collection.add(IngredientAmount(ConstantNode.decimal(Decimal(1) / Decimal(3)), "cup"))
         collection.add(IngredientAmount(ConstantNode.integer(1), "cup"))
@@ -80,7 +80,7 @@ class IngredientModelTests: XCTestCase {
     }
     
     func testWithPluralUnits() {
-        let collection = IngredientAmountCollection()
+        var collection = IngredientAmountCollection()
                 
         collection.add(IngredientAmount(ConstantNode.integer(1), "cup"))
         collection.add(IngredientAmount(ConstantNode.integer(2), "cups"))
@@ -90,7 +90,7 @@ class IngredientModelTests: XCTestCase {
     }
     
     func testWithPluralAndSingularIngredient() {
-        let collection = IngredientAmountCollection()
+        var collection = IngredientAmountCollection()
 
         collection.add(IngredientAmount(ConstantNode.integer(1), "onion"))
         collection.add(IngredientAmount(ConstantNode.integer(2), "onions"))
@@ -99,7 +99,7 @@ class IngredientModelTests: XCTestCase {
     }
     
     func testWithTextQuantity() {
-        let collection = IngredientAmountCollection()
+        var collection = IngredientAmountCollection()
                 
         collection.add(IngredientAmount(ConstantNode.string("few"), "springs"))
         

--- a/Tests/CookInSwiftTests/IngredientModelTests.swift
+++ b/Tests/CookInSwiftTests/IngredientModelTests.swift
@@ -16,13 +16,13 @@ class IngredientModelTests: XCTestCase {
     func testIngredientTableAddition() {
         var table1 = IngredientTable()
 
-        table1.add(name: "chilli", amount: IngredientAmount(ConstantNode.integer(3), "items"))
-        table1.add(name: "chilli", amount: IngredientAmount(ConstantNode.integer(1), "medium"))
+        table1.add(name: "chilli", amount: IngredientAmount(ValueNode.integer(3), "items"))
+        table1.add(name: "chilli", amount: IngredientAmount(ValueNode.integer(1), "medium"))
 
         var table2 = IngredientTable()
 
-        table2.add(name: "chilli", amount: IngredientAmount(ConstantNode.integer(5), "items"))
-        table1.add(name: "chilli", amount: IngredientAmount(ConstantNode.integer(3), "small"))
+        table2.add(name: "chilli", amount: IngredientAmount(ValueNode.integer(5), "items"))
+        table1.add(name: "chilli", amount: IngredientAmount(ValueNode.integer(3), "small"))
 
         XCTAssertEqual((table1 + table2).description, "chilli: 8 items, 1 medium, 3 small")
     }
@@ -30,8 +30,8 @@ class IngredientModelTests: XCTestCase {
     func testSameUnitsAndType() {
         var collection = IngredientAmountCollection()
         
-        collection.add(IngredientAmount(ConstantNode.integer(1), "g"))
-        collection.add(IngredientAmount(ConstantNode.integer(3), "g"))
+        collection.add(IngredientAmount(ValueNode.integer(1), "g"))
+        collection.add(IngredientAmount(ValueNode.integer(3), "g"))
             
         
         XCTAssertEqual(collection.description, "4 g")
@@ -40,9 +40,9 @@ class IngredientModelTests: XCTestCase {
     func testDifferentUnits() {
         var collection = IngredientAmountCollection()
         
-        collection.add(IngredientAmount(ConstantNode.integer(50), "g"))
-        collection.add(IngredientAmount(ConstantNode.integer(50), "g"))
-        collection.add(IngredientAmount(ConstantNode.integer(1), "kg"))
+        collection.add(IngredientAmount(ValueNode.integer(50), "g"))
+        collection.add(IngredientAmount(ValueNode.integer(50), "g"))
+        collection.add(IngredientAmount(ValueNode.integer(1), "kg"))
             
         
         XCTAssertEqual(collection.description, "100 g, 1 kg")
@@ -51,9 +51,9 @@ class IngredientModelTests: XCTestCase {
     func testDifferenQuantityTypes() {
         var collection = IngredientAmountCollection()
                 
-        collection.add(IngredientAmount(ConstantNode.integer(500), "g"))
-        collection.add(IngredientAmount(ConstantNode.decimal(1.5), "kg"))
-        collection.add(IngredientAmount(ConstantNode.decimal(1), "kg"))
+        collection.add(IngredientAmount(ValueNode.integer(500), "g"))
+        collection.add(IngredientAmount(ValueNode.decimal(1.5), "kg"))
+        collection.add(IngredientAmount(ValueNode.decimal(1), "kg"))
             
         
         XCTAssertEqual(collection.description, "500 g, 2.5 kg")
@@ -62,8 +62,8 @@ class IngredientModelTests: XCTestCase {
     func testFractionsQuantityTypes() {
         var collection = IngredientAmountCollection()
                 
-        collection.add(IngredientAmount(ConstantNode.decimal(0.5), "cup"))
-        collection.add(IngredientAmount(ConstantNode.integer(1), "cup"))
+        collection.add(IngredientAmount(ValueNode.decimal(0.5), "cup"))
+        collection.add(IngredientAmount(ValueNode.integer(1), "cup"))
             
         
         XCTAssertEqual(collection.description, "1.5 cups")
@@ -72,8 +72,8 @@ class IngredientModelTests: XCTestCase {
     func testFractionsQuantityDecimalTypes() {
         var collection = IngredientAmountCollection()
 
-        collection.add(IngredientAmount(ConstantNode.decimal(Decimal(1) / Decimal(3)), "cup"))
-        collection.add(IngredientAmount(ConstantNode.integer(1), "cup"))
+        collection.add(IngredientAmount(ValueNode.decimal(Decimal(1) / Decimal(3)), "cup"))
+        collection.add(IngredientAmount(ValueNode.integer(1), "cup"))
 
 
         XCTAssertEqual(collection.description, "1.3 cups")
@@ -82,8 +82,8 @@ class IngredientModelTests: XCTestCase {
     func testWithPluralUnits() {
         var collection = IngredientAmountCollection()
                 
-        collection.add(IngredientAmount(ConstantNode.integer(1), "cup"))
-        collection.add(IngredientAmount(ConstantNode.integer(2), "cups"))
+        collection.add(IngredientAmount(ValueNode.integer(1), "cup"))
+        collection.add(IngredientAmount(ValueNode.integer(2), "cups"))
             
         
         XCTAssertEqual(collection.description, "3 cups")
@@ -92,8 +92,8 @@ class IngredientModelTests: XCTestCase {
     func testWithPluralAndSingularIngredient() {
         var collection = IngredientAmountCollection()
 
-        collection.add(IngredientAmount(ConstantNode.integer(1), "onion"))
-        collection.add(IngredientAmount(ConstantNode.integer(2), "onions"))
+        collection.add(IngredientAmount(ValueNode.integer(1), "onion"))
+        collection.add(IngredientAmount(ValueNode.integer(2), "onions"))
 
         XCTAssertEqual(collection.description, "3 onions")
     }
@@ -101,7 +101,7 @@ class IngredientModelTests: XCTestCase {
     func testWithTextQuantity() {
         var collection = IngredientAmountCollection()
                 
-        collection.add(IngredientAmount(ConstantNode.string("few"), "springs"))
+        collection.add(IngredientAmount(ValueNode.string("few"), "springs"))
         
         XCTAssertEqual(collection.description, "few springs")
     }

--- a/Tests/CookInSwiftTests/IngredientModelTests.swift
+++ b/Tests/CookInSwiftTests/IngredientModelTests.swift
@@ -16,13 +16,13 @@ class IngredientModelTests: XCTestCase {
     func testIngredientTableAddition() {
         var table1 = IngredientTable()
 
-        table1.add(name: "chilli", amount: IngredientAmount(ValueNode.integer(3), "items"))
-        table1.add(name: "chilli", amount: IngredientAmount(ValueNode.integer(1), "medium"))
+        table1.add(name: "chilli", amount: IngredientAmount(3, "items"))
+        table1.add(name: "chilli", amount: IngredientAmount(1, "medium"))
 
         var table2 = IngredientTable()
 
-        table2.add(name: "chilli", amount: IngredientAmount(ValueNode.integer(5), "items"))
-        table1.add(name: "chilli", amount: IngredientAmount(ValueNode.integer(3), "small"))
+        table2.add(name: "chilli", amount: IngredientAmount(5, "items"))
+        table1.add(name: "chilli", amount: IngredientAmount(3, "small"))
 
         XCTAssertEqual(mergeIngredientTables(table1, table2).description, "chilli: 8 items, 1 medium, 3 small")
     }
@@ -30,8 +30,8 @@ class IngredientModelTests: XCTestCase {
     func testSameUnitsAndType() {
         var collection = IngredientAmountCollection()
         
-        collection.add(IngredientAmount(ValueNode.integer(1), "g"))
-        collection.add(IngredientAmount(ValueNode.integer(3), "g"))
+        collection.add(IngredientAmount(1, "g"))
+        collection.add(IngredientAmount(3, "g"))
             
         
         XCTAssertEqual(collection.description, "4 g")
@@ -40,9 +40,9 @@ class IngredientModelTests: XCTestCase {
     func testDifferentUnits() {
         var collection = IngredientAmountCollection()
         
-        collection.add(IngredientAmount(ValueNode.integer(50), "g"))
-        collection.add(IngredientAmount(ValueNode.integer(50), "g"))
-        collection.add(IngredientAmount(ValueNode.integer(1), "kg"))
+        collection.add(IngredientAmount(50, "g"))
+        collection.add(IngredientAmount(50, "g"))
+        collection.add(IngredientAmount(1, "kg"))
             
         
         XCTAssertEqual(collection.description, "100 g, 1 kg")
@@ -51,9 +51,9 @@ class IngredientModelTests: XCTestCase {
     func testDifferenQuantityTypes() {
         var collection = IngredientAmountCollection()
                 
-        collection.add(IngredientAmount(ValueNode.integer(500), "g"))
-        collection.add(IngredientAmount(ValueNode.decimal(1.5), "kg"))
-        collection.add(IngredientAmount(ValueNode.decimal(1), "kg"))
+        collection.add(IngredientAmount(500, "g"))
+        collection.add(IngredientAmount(1.5, "kg"))
+        collection.add(IngredientAmount(Decimal(1), "kg"))
             
         
         XCTAssertEqual(collection.description, "500 g, 2.5 kg")
@@ -62,8 +62,8 @@ class IngredientModelTests: XCTestCase {
     func testFractionsQuantityTypes() {
         var collection = IngredientAmountCollection()
                 
-        collection.add(IngredientAmount(ValueNode.decimal(0.5), "cup"))
-        collection.add(IngredientAmount(ValueNode.integer(1), "cup"))
+        collection.add(IngredientAmount(0.5, "cup"))
+        collection.add(IngredientAmount(1, "cup"))
             
         
         XCTAssertEqual(collection.description, "1.5 cups")
@@ -72,8 +72,8 @@ class IngredientModelTests: XCTestCase {
     func testFractionsQuantityDecimalTypes() {
         var collection = IngredientAmountCollection()
 
-        collection.add(IngredientAmount(ValueNode.decimal(Decimal(1) / Decimal(3)), "cup"))
-        collection.add(IngredientAmount(ValueNode.integer(1), "cup"))
+        collection.add(IngredientAmount(Decimal(1) / Decimal(3), "cup"))
+        collection.add(IngredientAmount(1, "cup"))
 
 
         XCTAssertEqual(collection.description, "1.3 cups")
@@ -82,8 +82,8 @@ class IngredientModelTests: XCTestCase {
     func testWithPluralUnits() {
         var collection = IngredientAmountCollection()
                 
-        collection.add(IngredientAmount(ValueNode.integer(1), "cup"))
-        collection.add(IngredientAmount(ValueNode.integer(2), "cups"))
+        collection.add(IngredientAmount(1, "cup"))
+        collection.add(IngredientAmount(2, "cups"))
             
         
         XCTAssertEqual(collection.description, "3 cups")
@@ -92,8 +92,8 @@ class IngredientModelTests: XCTestCase {
     func testWithPluralAndSingularIngredient() {
         var collection = IngredientAmountCollection()
 
-        collection.add(IngredientAmount(ValueNode.integer(1), "onion"))
-        collection.add(IngredientAmount(ValueNode.integer(2), "onions"))
+        collection.add(IngredientAmount(1, "onion"))
+        collection.add(IngredientAmount(2, "onions"))
 
         XCTAssertEqual(collection.description, "3 onions")
     }
@@ -101,7 +101,7 @@ class IngredientModelTests: XCTestCase {
     func testWithTextQuantity() {
         var collection = IngredientAmountCollection()
                 
-        collection.add(IngredientAmount(ValueNode.string("few"), "springs"))
+        collection.add(IngredientAmount("few", "springs"))
         
         XCTAssertEqual(collection.description, "few springs")
     }

--- a/Tests/CookInSwiftTests/IngredientModelTests.swift
+++ b/Tests/CookInSwiftTests/IngredientModelTests.swift
@@ -24,7 +24,7 @@ class IngredientModelTests: XCTestCase {
         table2.add(name: "chilli", amount: IngredientAmount(ValueNode.integer(5), "items"))
         table1.add(name: "chilli", amount: IngredientAmount(ValueNode.integer(3), "small"))
 
-        XCTAssertEqual((table1 + table2).description, "chilli: 8 items, 1 medium, 3 small")
+        XCTAssertEqual(mergeIngredientTables(table1, table2).description, "chilli: 8 items, 1 medium, 3 small")
     }
 
     func testSameUnitsAndType() {

--- a/Tests/CookInSwiftTests/SemanticAnalyzerTests.swift
+++ b/Tests/CookInSwiftTests/SemanticAnalyzerTests.swift
@@ -18,10 +18,7 @@ class SemanticAnalyzerTests: XCTestCase {
             Add @chilli{3}, @ginger{10%g} and @milk{1%litre} place in #oven and cook for ~{10%minutes}
             """
 
-        let node = try! Parser.parse(program) as! RecipeNode
-
-        let analyzer = SemanticAnalyzer()
-        let parsedRecipe = analyzer.analyze(node: node)
+        let parsedRecipe = try! Recipe.from(text: program)
 
         var recipe = Recipe()
         recipe.metadata["cooking time"] = "30 min"
@@ -61,8 +58,8 @@ class SemanticAnalyzerTests: XCTestCase {
             Simmer @milk{250%ml} with @honey{2%tbsp} for ~{20%minutes}. Add a bit of @cinnamon.
             """
 
-        let parsedRecipe1 = SemanticAnalyzer().analyze(node: try! Parser.parse(recipe1))
-        let parsedRecipe2 = SemanticAnalyzer().analyze(node: try! Parser.parse(recipe2))
+        let parsedRecipe1 = try! Recipe.from(text: recipe1)
+        let parsedRecipe2 = try! Recipe.from(text: recipe2)
 
         var table = IngredientTable()
 
@@ -116,10 +113,7 @@ class SemanticAnalyzerTests: XCTestCase {
 
 
         measure {
-            let analyzer = SemanticAnalyzer()
-
-            let node = try! Parser.parse(recipe) as! RecipeNode
-            let parsedRecipe = analyzer.analyze(node: node)
+            let parsedRecipe = try! Recipe.from(text: recipe)
 
             XCTAssertEqual(parsedRecipe.ingredientsTable.description, "avocados: 2; black pepper: some; butter: 30 g; cannellini beans: 2 tins; cheddar cheese: 75 g; cherry tomatoes: 10; coriander: 1 bunch; eggs: 8 large; fresh red chilli: 2; garlic clove: 2; ground cumin: 1 pinch; lime: 2; olive oil: 1 tbsp; red chilli: 1 item; red onion: 1; salt: some; sea salt: some; smoked paprika: 1 pinch; sour cream: 200 ml; tinned tomatoes: 2 tins; tortillas: 6 large")
         }
@@ -154,11 +148,7 @@ class SemanticAnalyzerTests: XCTestCase {
 
             """
 
-
-        let analyzer = SemanticAnalyzer()
-
-        let node = try! Parser.parse(recipe) as! RecipeNode
-        let parsedRecipe = analyzer.analyze(node: node)
+        let parsedRecipe = try! Recipe.from(text: recipe)
 
         XCTAssertEqual(parsedRecipe.ingredientsTable.description, "bay leaves: 2; black pepper: 1 tsp; carrots: 1 large; garlic: 1 glove; ground coriander: 1 tsp; ground cumin: 1 tsp; lamb: 450 g; linguine pasta: 230 g; oil: some; onion: 1 medium; potatoes: 420 g; red peppers: 0.5 large; star anise: 1 small; tomatoes: 2 large; water: 1.4 kg")
 
@@ -190,11 +180,7 @@ class SemanticAnalyzerTests: XCTestCase {
             Enjoy with butter and sour cream.
             """
 
-
-        let analyzer = SemanticAnalyzer()
-
-        let node = try! Parser.parse(recipe) as! RecipeNode
-        let parsedRecipe = analyzer.analyze(node: node)
+        let parsedRecipe = try! Recipe.from(text: recipe)
 
         XCTAssertEqual(parsedRecipe.ingredientsTable.description, "black pepper: 0.25 tsp; butter: 110 g; chicken thighs: 450 g; egg: 1 large; flour: 530 g; garlic: 2 cloves; ground coriander: 0.5 tsp; ground cumin: 0.25 tsp; milk: 160 g; onion: 1 small; parsley: 1 bunch; potatoes: 450 g; salt: 1 tsp; water: 180 g")
 
@@ -239,11 +225,7 @@ class SemanticAnalyzerTests: XCTestCase {
             Enjoy with butter and sour cream.
             """
 
-
-        let analyzer = SemanticAnalyzer()
-
-        let node = try! Parser.parse(recipe) as! RecipeNode
-        let parsedRecipe = analyzer.analyze(node: node)
+        let parsedRecipe = try! Recipe.from(text: recipe)
 
         let text = parsedRecipe.steps.map{ step in
             step.directions.map { $0.description }.joined()

--- a/Tests/CookInSwiftTests/SemanticAnalyzerTests.swift
+++ b/Tests/CookInSwiftTests/SemanticAnalyzerTests.swift
@@ -66,7 +66,7 @@ class SemanticAnalyzerTests: XCTestCase {
 
         var table = IngredientTable()
 
-        table = table + parsedRecipe1.ingredientsTable + parsedRecipe2.ingredientsTable
+        table = mergeIngredientTables(parsedRecipe1.ingredientsTable, parsedRecipe2.ingredientsTable)
 
         XCTAssertEqual(table.description, "chilli: 3; cinnamon: some; ginger: 10 g; honey: 2 tbsp; milk: 1 litre, 250 ml")
     }

--- a/Tests/CookInSwiftTests/SemanticAnalyzerTests.swift
+++ b/Tests/CookInSwiftTests/SemanticAnalyzerTests.swift
@@ -61,15 +61,14 @@ class SemanticAnalyzerTests: XCTestCase {
             Simmer @milk{250%ml} with @honey{2%tbsp} for ~{20%minutes}. Add a bit of @cinnamon.
             """
 
-        let analyzer = SemanticAnalyzer()
-        let parsedRecipe1 = analyzer.analyze(node: try! Parser.parse(recipe1))
-        let parsedRecipe2 = analyzer.analyze(node: try! Parser.parse(recipe2))
+        let parsedRecipe1 = SemanticAnalyzer().analyze(node: try! Parser.parse(recipe1))
+        let parsedRecipe2 = SemanticAnalyzer().analyze(node: try! Parser.parse(recipe2))
 
         var table = IngredientTable()
 
         table = table + parsedRecipe1.ingredientsTable + parsedRecipe2.ingredientsTable
 
-        XCTAssertEqual(table.description, "chilli: 6; cinnamon: some; ginger: 20 g; honey: 4 tbsp; milk: 2 litres, 500 ml")
+        XCTAssertEqual(table.description, "chilli: 3; cinnamon: some; ginger: 10 g; honey: 2 tbsp; milk: 1 litre, 250 ml")
     }
     
 //    test valid ingridient: when only units, but no name of in

--- a/Tests/CookInSwiftTests/SemanticAnalyzerTests.swift
+++ b/Tests/CookInSwiftTests/SemanticAnalyzerTests.swift
@@ -23,21 +23,21 @@ class SemanticAnalyzerTests: XCTestCase {
         let analyzer = SemanticAnalyzer()
         let parsedRecipe = analyzer.analyze(node: node)
 
-        let recipe = SemanticRecipe()
+        var recipe = Recipe()
         recipe.metadata["cooking time"] = "30 min"
 
-        let step = SemanticStep()
+        var step = Step()
         step.directions = [
             TextItem("Add "),
-            ParsedIngredient("chilli", IngredientAmount(3, "items")),
+            Ingredient("chilli", IngredientAmount(3, "items")),
             TextItem(", "),
-            ParsedIngredient("ginger", IngredientAmount(10, "g")),
+            Ingredient("ginger", IngredientAmount(10, "g")),
             TextItem(" and "),
-            ParsedIngredient("milk", IngredientAmount(1, "litre")),
+            Ingredient("milk", IngredientAmount(1, "litre")),
             TextItem(" place in "),
-            ParsedEquipment("oven"),
+            Equipment("oven"),
             TextItem(" and cook for "),
-            ParsedTimer(10, "minutes")
+            Timer(10, "minutes")
         ]
         recipe.steps = [step]
 


### PR DESCRIPTION
- [x] Migrate public API types from classes to structs for better local reasoning. (e.g `struct {Recipe,Ingredient,Step}`)
- [x] Improve some of the names (e.g ParsedEquipment -> Equipment, SemanticRecipe -> Recipe)
- [x] Extract IngredientTable composition as a helper method.
- [x] Remove parsing types from the public API (e.g IngredientAmount.value could be a Decimal rather than a ValueNode)
- [x] Provide some convenience methods like `let recipe = try Recipe.from(text: String)`

Re: https://github.com/cooklang/CookInSwift/issues/6.